### PR TITLE
Feature/turbo

### DIFF
--- a/src/config/constants/contracts.ts
+++ b/src/config/constants/contracts.ts
@@ -1,4 +1,75 @@
-export default {
+export const defaultContracts =  {
+  nova: {
+    56: '0x56E344bE9A7a7A1d27C854628483Efd67c11214F',
+    97: '0xBC241DFFf64583Bcc9889311B1044cB6B4e9eCaF',
+  },
+  snova: {
+    56: '0x0c0bf2bD544566A11f59dC70a8F43659ac2FE7c2',
+    97: '0xb79927bA8D1dF7B9c2199f3307Ddf6B263eBa6A3', 
+  },
+  masterChef: {
+    56: '0x8A4f4c7F4804D30c718a76B3fde75f2e0cFd8712',
+    97: '0xDDddD4d6a604A311CA2d90c54E81D2e31424B813',
+  },
+  wbnb: {
+    56: '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c',
+    97: '0xae13d989dac2f0debff460ac112a837c89baa7cd',
+  },
+  map: {
+    56: '0x5cC9B3A05e80915AcCc52134dc1a4ec1C733cc03',
+    97: '0xbd5d6A0BFcf8993E2E4352EfB95167c8b07c82D3',
+  },
+  fleet: {
+    56: '0x2E56f9B28e8fB49F6370e2a3505631fB7c99E295',
+    97: '0x20967ffC3CAA5CADB27ddff371617b4Ad6881Bf5',
+  },
+  treasury: {
+    56: '0x34b83e608eFe08dAE6F64A5E7eD0BDf6376e4243',
+    97: '0x1c24392880612D4E119E7961906514caDe8E3Be3', 
+  },
+  approvals: {
+    56: '0x12a8B6bc5DcBE9BD869ea8ad76a41c7D9f166d80',
+    97: '0x02A31F9fBf1a9b3fE82F1d20550778B73113722f',
+  },
+  referrals: {
+    56: '0x0c4645A8eF44b2f5d5b82c89f7F25a5Cb8494703',
+  },
+  lottery: {
+    56: '',
+    97: '',
+  },
+  lotteryNFT: {
+    56: '',
+    97: '',
+  },
+  mulltiCall: {
+    56: '0x1ee38d535d541c55c9dae27b12edf090c608e6fb',
+    97: '0x310185c34DeD9AF094af0Ce3aA4854e6C3880345',
+  },
+  busd: {
+    56: '0xe9e7cea3dedca5984780bafc599bd69add087d56',
+    97: '0xeD24FC36d5Ee211Ea25A80239Fb8C4Cfd80f12Ee',
+  },
+  moneyPot: {
+    // 0xF2c89d86338204856054ff50f1DeF2BD7f5256f0
+    56: '0xAD07Cf266C99d0cC379D4f460F0FF27b81314238',
+    97: '0x6099c4f8b42C4F41c070514EF48fCA00ca454710',
+  },
+  moneyPotOld: {
+    56:'0xAD07Cf266C99d0cC379D4f460F0FF27b81314238',
+    97:'0x6099c4f8b42C4F41c070514EF48fCA00ca454710'
+  },
+  eth: {
+    56: '0x2170ed0880ac9a755fd29b2688956bd959f933f8',
+    97: '0xC3C08346480c7d6059193d9B978F19682b15524A',
+  },
+  usdt: {
+    56: '0x55d398326f99059ff775485246999027b3197955',
+    97: '0x06CF87B8fC2140d4a0A4c0AC93Ef7C430a8d7AE3',
+  },
+}
+
+export const turboContracts =  {
   nova: {
     56: '0x56E344bE9A7a7A1d27C854628483Efd67c11214F',
     97: '0xBC241DFFf64583Bcc9889311B1044cB6B4e9eCaF',

--- a/src/config/constants/farms.ts
+++ b/src/config/constants/farms.ts
@@ -1,4 +1,4 @@
-import contracts from './contracts'
+import { defaultContracts as contracts } from './contracts'
 import { FarmConfig, QuoteToken } from './types'
 
 const farms: FarmConfig[] = [

--- a/src/contexts/NovariaTurboContext.tsx
+++ b/src/contexts/NovariaTurboContext.tsx
@@ -1,0 +1,5 @@
+import React, { useState, useEffect, useRef } from 'react'
+
+const NovariaTurboContext = React.createContext(false)
+
+export default NovariaTurboContext

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -12,7 +12,6 @@ import {
   getMoneyPotOldAddress,
   getFleetAddress,
   getMapAddress,
-  getApprovalsAddress,
   getReferralsAddress,
   getTreasuryAddress,
 } from 'utils/addressHelpers'
@@ -116,11 +115,6 @@ export const useMap = () => {
   const turbo = useContext(NovariaTurboContext)
   const mapABI = map as unknown as AbiItem
   return useContract(mapABI, getMapAddress(turbo))
-}
-
-export const useApprovals = () => {
-  const approvalsABI = approvals as unknown as AbiItem
-  return useContract(approvalsABI, getApprovalsAddress())
 }
 
 export const useReferrals = () => {

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -13,7 +13,8 @@ import {
   getFleetAddress,
   getMapAddress,
   getApprovalsAddress,
-  getReferralsAddress
+  getReferralsAddress,
+  getTreasuryAddress
 } from 'utils/addressHelpers'
 import { poolsConfig } from 'config/constants'
 import { PoolCategory } from 'config/constants/types'
@@ -31,6 +32,7 @@ import fleet from 'config/abi/Fleet.json'
 import referrals from 'config/abi/Referrals.json'
 import map from 'config/abi/Map.json'
 import approvals from 'config/abi/Approvals.json'
+import treasury from 'config/abi/Treasury.json'
 
 const useContract = (abi: AbiItem, address: string, contractOptions?: ContractOptions) => {
   const web3 = useWeb3()
@@ -121,6 +123,11 @@ export const useApprovals = () => {
 export const useReferrals = () => {
   const referralsABI = referrals as unknown as AbiItem
   return useContract(referralsABI, getReferralsAddress())
+}
+
+export const useTreasury = () => {
+  const treasuryABI = treasury as unknown as AbiItem
+  return useContract(treasuryABI, getTreasuryAddress())
 }
 
 export default useContract

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { AbiItem } from 'web3-utils'
 import { ContractOptions } from 'web3-eth-contract'
 import useWeb3 from 'hooks/useWeb3'
@@ -14,7 +14,7 @@ import {
   getMapAddress,
   getApprovalsAddress,
   getReferralsAddress,
-  getTreasuryAddress
+  getTreasuryAddress,
 } from 'utils/addressHelpers'
 import { poolsConfig } from 'config/constants'
 import { PoolCategory } from 'config/constants/types'
@@ -33,6 +33,7 @@ import referrals from 'config/abi/Referrals.json'
 import map from 'config/abi/Map.json'
 import approvals from 'config/abi/Approvals.json'
 import treasury from 'config/abi/Treasury.json'
+import NovariaTurboContext from 'contexts/NovariaTurboContext'
 
 const useContract = (abi: AbiItem, address: string, contractOptions?: ContractOptions) => {
   const web3 = useWeb3()
@@ -106,13 +107,15 @@ export const useSNova = () => {
 }
 
 export const useFleet = () => {
+  const turbo = useContext(NovariaTurboContext)
   const fleetABI = fleet as unknown as AbiItem
-  return useContract(fleetABI, getFleetAddress())
+  return useContract(fleetABI, getFleetAddress(turbo))
 }
 
 export const useMap = () => {
+  const turbo = useContext(NovariaTurboContext)
   const mapABI = map as unknown as AbiItem
-  return useContract(mapABI, getMapAddress())
+  return useContract(mapABI, getMapAddress(turbo))
 }
 
 export const useApprovals = () => {
@@ -121,13 +124,15 @@ export const useApprovals = () => {
 }
 
 export const useReferrals = () => {
+  const turbo = useContext(NovariaTurboContext)
   const referralsABI = referrals as unknown as AbiItem
-  return useContract(referralsABI, getReferralsAddress())
+  return useContract(referralsABI, getReferralsAddress(turbo))
 }
 
 export const useTreasury = () => {
+  const turbo = useContext(NovariaTurboContext)
   const treasuryABI = treasury as unknown as AbiItem
-  return useContract(treasuryABI, getTreasuryAddress())
+  return useContract(treasuryABI, getTreasuryAddress(turbo))
 }
 
 export default useContract

--- a/src/hooks/useNovaria.ts
+++ b/src/hooks/useNovaria.ts
@@ -1,12 +1,5 @@
 import { useEffect, useState, useCallback } from 'react'
 import { useWallet } from '@binance-chain/bsc-use-wallet'
-import novaABI from 'config/abi/nova.json'
-import fleetABI from 'config/abi/Fleet.json'
-import mapABI from 'config/abi/Map.json'
-import treasuryABI from 'config/abi/Treasury.json'
-import ReferralsABI from 'config/abi/Referrals.json'
-import { getContract } from 'utils/web3'
-import { getNovaAddress, getFleetAddress, getMapAddress, getTreasuryAddress, getReferralsAddress } from 'utils/addressHelpers'
 import {
   buildShips,
   claimShips,
@@ -31,15 +24,8 @@ import {
   setRecall,
 } from 'utils/callHelpers'
 import BigNumber from 'bignumber.js'
-import { useFleet, useMap, useNova, useReferrals } from './useContract'
+import { useFleet, useMap, useNova, useReferrals, useTreasury } from './useContract'
 import useRefresh from './useRefresh'
-
-// Contract constants
-const fleetContract = getContract(fleetABI, getFleetAddress())
-const mapContract = getContract(mapABI, getMapAddress())
-const novaContract = getContract(novaABI, getNovaAddress())
-const treasuryContract = getContract(treasuryABI, getTreasuryAddress())
-const referralsContract = getContract(ReferralsABI, getReferralsAddress())
 
 // ~~~Fleet contract functions~~~
 // player setup and current ships, building ships, combat
@@ -184,6 +170,7 @@ export const useSetShipyardFee = () => {
 // ***View functions***
 
 export const useGetShipClasses = () => {
+  const fleetContract = useFleet()
   const { fastRefresh } = useRefresh()
   const [shipClasses, setShipClasses] = useState([])
 
@@ -194,11 +181,12 @@ export const useGetShipClasses = () => {
     }
 
     fetchshipClasses()
-  }, [fastRefresh])
+  }, [fleetContract, fastRefresh])
   return shipClasses
 }
 
 export const useGetBuildTime = (shipId: number, amount: number) => {
+  const fleetContract = useFleet()
   const { fastRefresh } = useRefresh()
   const [BuildTime, setBuildTime] = useState(0)
 
@@ -208,11 +196,12 @@ export const useGetBuildTime = (shipId: number, amount: number) => {
       setBuildTime(data)
     }
     fetch()
-  }, [fastRefresh, shipId, amount])
+  }, [shipId, amount, fleetContract, fastRefresh])
   return BuildTime
 }
 
 export const useGetShipyards = () => {
+  const fleetContract = useFleet()
   const { fastRefresh } = useRefresh()
   const [shipyards, setShipyards] = useState([])
 
@@ -222,11 +211,12 @@ export const useGetShipyards = () => {
       setShipyards(data)
     }
     fetchShipyards()
-  }, [fastRefresh])
+  }, [fleetContract, fastRefresh])
   return shipyards
 }
 
 export const useGetSpaceDock = (player: string) => {
+  const fleetContract = useFleet()
   const { fastRefresh } = useRefresh()
   const [spaceDock, setSpaceDock] = useState([])
 
@@ -236,11 +226,12 @@ export const useGetSpaceDock = (player: string) => {
       setSpaceDock(data)
     }
     fetchSpaceDock()
-  }, [fastRefresh, player])
+  }, [player, fleetContract, fastRefresh])
   return spaceDock
 }
 
 export const useGetShips = (fleet: string) => {
+  const fleetContract = useFleet()
   const { fastRefresh } = useRefresh()
   const [ships, setShips] = useState([])
 
@@ -250,11 +241,12 @@ export const useGetShips = (fleet: string) => {
       setShips(data)
     }
     fetchShips()
-  }, [fastRefresh, fleet])
+  }, [fleet, fleetContract, fastRefresh])
   return ships
 }
 
 export const useGetFleetSize = (fleet: string) => {
+  const fleetContract = useFleet()
   const { fastRefresh } = useRefresh()
   const [fleetSize, setFleetSize] = useState(0)
 
@@ -264,11 +256,12 @@ export const useGetFleetSize = (fleet: string) => {
       setFleetSize(data)
     }
     fetch()
-  }, [fastRefresh, fleet])
+  }, [fleet, fleetContract, fastRefresh])
   return fleetSize
 }
 
 export const useGetMaxFleetSize = (fleet: string) => {
+  const fleetContract = useFleet()
   const { fastRefresh } = useRefresh()
   const [maxFleetSize, setMAxFleetSize] = useState(null)
 
@@ -278,11 +271,12 @@ export const useGetMaxFleetSize = (fleet: string) => {
       setMAxFleetSize(data)
     }
     fetch()
-  }, [fastRefresh, fleet])
+  }, [fleet, fleetContract, fastRefresh])
   return maxFleetSize
 }
 
 export const useGetFleetMineral = (fleet: string) => {
+  const fleetContract = useFleet()
   const { fastRefresh } = useRefresh()
   const [fleetMineral, setFleetMineral] = useState('')
 
@@ -292,11 +286,12 @@ export const useGetFleetMineral = (fleet: string) => {
       setFleetMineral(data)
     }
     fetch()
-  }, [fastRefresh, fleet])
+  }, [fleet, fleetContract, fastRefresh])
   return fleetMineral
 }
 
 export const useGetMaxMineralCapacity = (fleet: string) => {
+  const fleetContract = useFleet()
   const { fastRefresh } = useRefresh()
   const [maxMineralCapacity, setMaxMineralCapacity] = useState('')
 
@@ -306,11 +301,12 @@ export const useGetMaxMineralCapacity = (fleet: string) => {
       setMaxMineralCapacity(data)
     }
     fetch()
-  }, [fastRefresh, fleet])
+  }, [fleet, fleetContract, fastRefresh])
   return maxMineralCapacity
 }
 
 export const useGetMiningCapacity = (fleet: string) => {
+  const fleetContract = useFleet()
   const { fastRefresh } = useRefresh()
   const [miningCapacity, setMiningCapacity] = useState('')
 
@@ -320,12 +316,13 @@ export const useGetMiningCapacity = (fleet: string) => {
       setMiningCapacity(data)
     }
     fetch()
-  }, [fastRefresh, fleet])
+  }, [fleet, fleetContract, fastRefresh])
   return miningCapacity
 }
 
 // returns list of battle IDs at a location
 export const useGetBattlesAtLocation = (x: any, y: any, startTime: number, endTime: number) => {
+  const fleetContract = useFleet()
   const { fastRefresh } = useRefresh()
   const [battlesAtLocation, setBattlesAtLocation] = useState([])
 
@@ -337,12 +334,13 @@ export const useGetBattlesAtLocation = (x: any, y: any, startTime: number, endTi
       }
     }
     fetch()
-  }, [fastRefresh, x, y, startTime, endTime])
+  }, [x, y, startTime, endTime, fleetContract, fastRefresh])
   return battlesAtLocation
 }
 
 // returns battle info
 export const useGetBattle = (Id: number) => {
+  const fleetContract = useFleet()
   const { fastRefresh } = useRefresh()
   const [battle, setBattle] = useState({
     attackTeam: [],
@@ -370,12 +368,13 @@ export const useGetBattle = (Id: number) => {
       })
     }
     fetch()
-  }, [fastRefresh, Id])
+  }, [Id, fleetContract, fastRefresh])
   return battle
 }
 
 // returns battle info of player
 export const useGetPlayerBattle = (player) => {
+  const fleetContract = useFleet()
   const { fastRefresh } = useRefresh()
   const [PlayerBattle, setPlayerBattle] = useState({ battleStatus: 0, battleId: null })
 
@@ -388,11 +387,12 @@ export const useGetPlayerBattle = (player) => {
       })
     }
     fetch()
-  }, [fastRefresh, player])
+  }, [player, fleetContract, fastRefresh])
   return PlayerBattle
 }
 
 export const useGetPlayerBattleStatus = (player) => {
+  const fleetContract = useFleet()
   const { fastRefresh } = useRefresh()
   const [PlayerBattleStatus, setPlayerBattleStatus] = useState(false)
 
@@ -402,11 +402,12 @@ export const useGetPlayerBattleStatus = (player) => {
       setPlayerBattleStatus(data)
     }
     fetch()
-  }, [fastRefresh, player])
+  }, [player, fleetContract, fastRefresh])
   return PlayerBattleStatus
 }
 
 export const useGetAttackPower = (fleet) => {
+  const fleetContract = useFleet()
   const { fastRefresh } = useRefresh()
   const [attackPower, setAttackPower] = useState(0)
 
@@ -416,11 +417,12 @@ export const useGetAttackPower = (fleet) => {
       setAttackPower(data)
     }
     fetch()
-  }, [fastRefresh, fleet])
+  }, [fleet, fleetContract, fastRefresh])
   return attackPower
 }
 
 export const useGetPlayer = (player) => {
+  const fleetContract = useFleet()
   const { fastRefresh } = useRefresh()
   const [Player, setPlayer] = useState({
     name: '',
@@ -447,11 +449,12 @@ export const useGetPlayer = (player) => {
       }
     }
     fetch()
-  }, [fastRefresh, player])
+  }, [player, fleetContract, fastRefresh])
   return Player
 }
 
 export const useGetNameByAddress = (player) => {
+  const fleetContract = useFleet()
   const { fastRefresh } = useRefresh()
   const [name, setName] = useState('')
 
@@ -470,11 +473,12 @@ export const useGetNameByAddress = (player) => {
       }
     }
     fetch()
-  }, [fastRefresh, player])
+  }, [player, fleetContract, fastRefresh])
   return name
 }
 
 export const useGetPlayerExists = (player) => {
+  const fleetContract = useFleet()
   const { fastRefresh } = useRefresh()
   const [PlayerExists, setPlayerExists] = useState(false)
 
@@ -484,11 +488,12 @@ export const useGetPlayerExists = (player) => {
       setPlayerExists(data)
     }
     fetch()
-  }, [fastRefresh, player])
+  }, [player, fleetContract, fastRefresh])
   return PlayerExists
 }
 
 export const useGetDockCost = (shipClassId: number, amount: number) => {
+  const fleetContract = useFleet()
   const { fastRefresh } = useRefresh()
   const [DockCost, setDockCost] = useState(0)
 
@@ -498,11 +503,12 @@ export const useGetDockCost = (shipClassId: number, amount: number) => {
       setDockCost(data)
     }
     fetch()
-  }, [fastRefresh, shipClassId, amount])
+  }, [shipClassId, amount, fleetContract, fastRefresh])
   return DockCost
 }
 
 export const useGetPlayerInBattle = (account) => {
+  const fleetContract = useFleet()
   const { fastRefresh } = useRefresh()
   const [playerInBattle, setPlayerInBattle] = useState(false)
 
@@ -512,7 +518,7 @@ export const useGetPlayerInBattle = (account) => {
       setPlayerInBattle(data)
     }
     fetch()
-  }, [fastRefresh, account])
+  }, [account, fleetContract, fastRefresh])
   return playerInBattle
 }
 
@@ -636,6 +642,7 @@ export const useRecall = () => {
 // ***View Functions***
 
 export const useGetSavedSpawnPlace = (account) => {
+  const mapContract = useMap()
   const { fastRefresh } = useRefresh()
   const [savedPlace, setSavedPlace] = useState({x: 0, y: 0})
 
@@ -645,11 +652,12 @@ export const useGetSavedSpawnPlace = (account) => {
       const place = await mapContract.methods.places(placeId).call()
       setSavedPlace({x: place.coordX, y: place.coordY})
     } fetch()
-  }, [fastRefresh, account])
+  }, [account, mapContract, fastRefresh])
   return savedPlace
 }
 
 export const useGetPlayerCount = () => {
+  const fleetContract = useFleet()
   const { fastRefresh } = useRefresh()
   const [playerCount, setPlayerCount] = useState(0)
 
@@ -659,11 +667,12 @@ export const useGetPlayerCount = () => {
       setPlayerCount(data)
     }
     fetch()
-  }, [fastRefresh])
+  }, [fleetContract, fastRefresh])
   return playerCount
 }
 
 export const useGetFleetMineralRefined = (account) => {
+  const mapContract = useMap()
   const { fastRefresh } = useRefresh()
   const [mineralRefined, setmineralRefined] = useState(0)
 
@@ -673,11 +682,12 @@ export const useGetFleetMineralRefined = (account) => {
       setmineralRefined(data)
     }
     fetch()
-  }, [fastRefresh, account])
+  }, [account, mapContract, fastRefresh])
   return mineralRefined
 }
 
 export const useGetFleetLocation = (fleet) => {
+  const mapContract = useMap()
   const { fastRefresh } = useRefresh()
   const [fleetLocation, setFleetLocation] = useState({ X: 0, Y: 0 })
 
@@ -687,11 +697,12 @@ export const useGetFleetLocation = (fleet) => {
       setFleetLocation({ X: data.x, Y: data.y })
     }
     fetch()
-  }, [fastRefresh, fleet])
+  }, [fleet, mapContract, fastRefresh])
   return fleetLocation
 }
 
 export const useGetExploreCost = (x, y, account) => {
+  const mapContract = useMap()
   const { fastRefresh } = useRefresh()
   const [ExploreCost, setExploreCost] = useState(0)
 
@@ -701,11 +712,12 @@ export const useGetExploreCost = (x, y, account) => {
       setExploreCost(data)
     }
     fetch()
-  }, [fastRefresh, x, y, account])
+  }, [x, y, account, mapContract, fastRefresh])
   return ExploreCost
 }
 
 export const useGetPlaceInfo = (x1: any, y1: any) => {
+  const mapContract = useMap()
   const { fastRefresh } = useRefresh()
   const [placeInfo, setPlaceInfo] = useState({
     name: '',
@@ -741,11 +753,12 @@ export const useGetPlaceInfo = (x1: any, y1: any) => {
       }
     }
     fetch()
-  }, [fastRefresh, x1, y1])
+  }, [x1, y1, mapContract, fastRefresh])
   return placeInfo
 }
 
 export const useGetFleetsAtLocation = (x: any, y: any) => {
+  const mapContract = useMap()
   const { fastRefresh } = useRefresh()
   const [fleetsAtLocation, setFleetsAtLocation] = useState([])
 
@@ -757,11 +770,12 @@ export const useGetFleetsAtLocation = (x: any, y: any) => {
       }
     }
     fetch()
-  }, [fastRefresh, x, y])
+  }, [x, y, mapContract, fastRefresh])
   return fleetsAtLocation
 }
 
 export const useGetDistanceFromFleet = (fleet: string, x: number, y: number) => {
+  const mapContract = useMap()
   const { fastRefresh } = useRefresh()
   const [DistanceFromFleet, setDistanceFromFleet] = useState(0)
 
@@ -771,11 +785,12 @@ export const useGetDistanceFromFleet = (fleet: string, x: number, y: number) => 
       setDistanceFromFleet(data)
     }
     fetch()
-  }, [fastRefresh, fleet, x, y])
+  }, [fleet, x, y, mapContract, fastRefresh])
   return DistanceFromFleet
 }
 
 export const useGetFleetTravelCost = (fleet: string, x: number, y: number) => {
+  const mapContract = useMap()
   const { fastRefresh } = useRefresh()
   const [FleetTravelCost, setFleetTravelCost] = useState(0)
 
@@ -785,11 +800,12 @@ export const useGetFleetTravelCost = (fleet: string, x: number, y: number) => {
       setFleetTravelCost(data)
     }
     fetch()
-  }, [fastRefresh, fleet, x, y])
+  }, [fleet, x, y, mapContract, fastRefresh])
   return FleetTravelCost
 }
 
 export const useGetTravelCooldown = (fleet: string, x: number, y: number) => {
+  const mapContract = useMap()
   const { fastRefresh } = useRefresh()
   const [TravelCooldown, setTravelCooldown] = useState(0)
 
@@ -799,11 +815,12 @@ export const useGetTravelCooldown = (fleet: string, x: number, y: number) => {
       setTravelCooldown(data)
     }
     fetch()
-  }, [fastRefresh, fleet, x, y])
+  }, [fleet, x, y, mapContract, fastRefresh])
   return TravelCooldown
 }
 
 export const useGetCurrentTravelCooldown = (fleet: string) => {
+  const mapContract = useMap()
   const { fastRefresh } = useRefresh()
   const [CurrentCooldown, setCurrentCooldown] = useState(0)
 
@@ -813,11 +830,12 @@ export const useGetCurrentTravelCooldown = (fleet: string) => {
       setCurrentCooldown(data)
     }
     fetch()
-  }, [fastRefresh, fleet])
+  }, [fleet, mapContract, fastRefresh])
   return CurrentCooldown
 }
 
 export const useGetCurrentMiningCooldown = (fleet: string) => {
+  const mapContract = useMap()
   const { fastRefresh } = useRefresh()
   const [currentCooldown, setCurrentCooldown] = useState(0)
 
@@ -827,7 +845,7 @@ export const useGetCurrentMiningCooldown = (fleet: string) => {
       setCurrentCooldown(data)
     }
     fetch()
-  }, [fastRefresh, fleet])
+  }, [fleet, mapContract, fastRefresh])
   return currentCooldown
 }
 
@@ -864,6 +882,7 @@ export const useApprove = () => {
 
 export const useGetAllowance = (contract) => {
   const { account } = useWallet()
+  const novaContract = useNova()
   const { fastRefresh } = useRefresh()
   const [allowance, setAllowance] = useState(null)
 
@@ -873,11 +892,12 @@ export const useGetAllowance = (contract) => {
       setAllowance(data)
     }
     fetch()
-  }, [fastRefresh, account, contract])
+  }, [contract, account, novaContract, fastRefresh])
   return allowance
 }
 
 export const useGetNovaBalance = (account) => {
+  const novaContract = useNova()
   const { fastRefresh } = useRefresh()
   const [balance, setBalance] = useState(0)
 
@@ -887,12 +907,13 @@ export const useGetNovaBalance = (account) => {
       setBalance(data)
     }
     fetch()
-  }, [fastRefresh, account])
+  }, [account, novaContract, fastRefresh])
   return balance
 }
 // *** Treasury Contract ***
 
 export const useGetCostMod = () => {
+  const treasuryContract = useTreasury()
   const { fastRefresh } = useRefresh()
   const [CostMod, setCostMod] = useState(0)
 
@@ -902,7 +923,7 @@ export const useGetCostMod = () => {
       setCostMod(data)
     }
     fetch()
-  }, [fastRefresh])
+  }, [treasuryContract, fastRefresh])
   return CostMod
 }
 
@@ -936,6 +957,7 @@ export const useGetReferralBonus = (player: string) => {
 }
 
 export const useCheckReferrals = (player: string) => {
+  const referralsContract = useReferrals()
   const { slowRefresh } = useRefresh()
   const [totalReferrals, settotalReferrals] = useState(0)
 
@@ -945,11 +967,12 @@ export const useCheckReferrals = (player: string) => {
       settotalReferrals(data)
     }
     fetch()
-  }, [player, slowRefresh])
+  }, [player, referralsContract, slowRefresh])
   return totalReferrals
 }
 
 export const useCheckReferralStatus = (player: string) => {
+  const referralsContract = useReferrals()
   const { slowRefresh } = useRefresh()
   const [referralStatus, setReferralStatus] = useState(false)
 
@@ -959,11 +982,12 @@ export const useCheckReferralStatus = (player: string) => {
       setReferralStatus(data)
     }
     fetch()
-  }, [player, slowRefresh])
+  }, [player, referralsContract, slowRefresh])
   return referralStatus
 }
 
 export const useGetTotalReferrals = (player: string) => {
+  const referralsContract = useReferrals()
   const {slowRefresh} = useRefresh()
   const [totalReferrals, settotalReferrals] = useState(0)
 
@@ -973,6 +997,6 @@ export const useGetTotalReferrals = (player: string) => {
       settotalReferrals(data)
     }
     fetch()
-  }, [player, slowRefresh])
+  }, [player, referralsContract, slowRefresh])
   return totalReferrals
 }

--- a/src/utils/addressHelpers.ts
+++ b/src/utils/addressHelpers.ts
@@ -40,9 +40,6 @@ export const getFleetAddress = (turbo: boolean) => {
   const contracts = turbo ? turboContracts : defaultContracts
   return contracts.fleet[chainId]
 }
-export const getApprovalsAddress = () => {
-  return defaultContracts.approvals[chainId]
-}
 export const getTreasuryAddress = (turbo: boolean) => {
   const contracts = turbo ? turboContracts : defaultContracts
   return contracts.treasury[chainId]

--- a/src/utils/addressHelpers.ts
+++ b/src/utils/addressHelpers.ts
@@ -1,49 +1,53 @@
-import addresses from 'config/constants/contracts'
+import { defaultContracts, turboContracts } from 'config/constants/contracts'
 
 const chainId = process.env.REACT_APP_CHAIN_ID
 
 export const getNovaAddress = () => {
-  return addresses.nova[chainId]
+  return defaultContracts.nova[chainId]
 }
 export const getMasterChefAddress = () => {
-  return addresses.masterChef[chainId]
+  return defaultContracts.masterChef[chainId]
 }
 export const getMulticallAddress = () => {
-  return addresses.mulltiCall[chainId]
+  return defaultContracts.mulltiCall[chainId]
 }
 export const getWbnbAddress = () => {
-  return addresses.wbnb[chainId]
+  return defaultContracts.wbnb[chainId]
 }
 export const getLotteryAddress = () => {
-  return addresses.lottery[chainId]
+  return defaultContracts.lottery[chainId]
 }
 export const getLotteryTicketAddress = () => {
-  return addresses.lotteryNFT[chainId]
+  return defaultContracts.lotteryNFT[chainId]
 }
 export const getSNovaAddress = () => {
-  return addresses.snova[chainId]
+  return defaultContracts.snova[chainId]
 }
 export const getMoneyPotAddress = () => {
-  return addresses.moneyPot[chainId]
+  return defaultContracts.moneyPot[chainId]
 }
 export const getMoneyPotOldAddress = () => {
-  return addresses.moneyPotOld[chainId]
+  return defaultContracts.moneyPotOld[chainId]
 }
 export const getBusdAddress = () => {
-  return addresses.busd[chainId]
+  return defaultContracts.busd[chainId]
 }
-export const getMapAddress = () => {
-  return addresses.map[chainId]
+export const getMapAddress = (turbo: boolean) => {
+  const contracts = turbo ? turboContracts : defaultContracts
+  return contracts.map[chainId]
 }
-export const getFleetAddress = () => {
-  return addresses.fleet[chainId]
+export const getFleetAddress = (turbo: boolean) => {
+  const contracts = turbo ? turboContracts : defaultContracts
+  return contracts.fleet[chainId]
 }
 export const getApprovalsAddress = () => {
-  return addresses.approvals[chainId]
+  return defaultContracts.approvals[chainId]
 }
-export const getTreasuryAddress = () => {
-  return addresses.treasury[chainId]
+export const getTreasuryAddress = (turbo: boolean) => {
+  const contracts = turbo ? turboContracts : defaultContracts
+  return contracts.treasury[chainId]
 }
-export const getReferralsAddress = () => {
-  return addresses.referrals[chainId]
+export const getReferralsAddress = (turbo: boolean) => {
+  const contracts = turbo ? turboContracts : defaultContracts
+  return contracts.referrals[chainId]
 }

--- a/src/views/Novaria/Overview/Overview.tsx
+++ b/src/views/Novaria/Overview/Overview.tsx
@@ -28,6 +28,7 @@ import {
 } from 'hooks/useNovaria'
 import { ConnectedAccountContext } from 'App'
 import { getTreasuryAddress } from 'utils/addressHelpers'
+import NovariaTurboContext from 'contexts/NovariaTurboContext'
 import GameHeader from '../components/GameHeader'
 import GameMenu from '../components/GameMenu'
 import GameRankings from '../components/GameRankings'
@@ -253,7 +254,8 @@ const Overview: React.FC = () => {
   const rewardsAmount = useCheckReferrals(account) * 25
   const rewardsDisabled = rewardsAmount <= 0 || pending
   const totalReferrals = useGetTotalReferrals(account)
-  const asteroidMineral = Number(useGetNovaBalance(getTreasuryAddress())/10**19).toFixed(0)
+  const turbo = useContext(NovariaTurboContext)
+  const asteroidMineral = Number(useGetNovaBalance(getTreasuryAddress(turbo))/10**19).toFixed(0)
 
   const { onGet } = useGetReferralBonus(account)
 

--- a/src/views/Novaria/components/Banner.tsx
+++ b/src/views/Novaria/components/Banner.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react'
+import React, { useContext, useState } from 'react'
 import styled from 'styled-components'
 import { useGetAllowance, useApprove } from 'hooks/useNovaria'
 import { getTreasuryAddress } from 'utils/addressHelpers'
+import NovariaTurboContext from 'contexts/NovariaTurboContext'
 
 const Wrapper = styled.div`
   display: flex;
@@ -44,7 +45,8 @@ const Button = styled.button`
 const UpdateBanner = () => {
   const [pendingApprove, setPendingApproveTx] = useState(false)
 
-  const treasuryContract = getTreasuryAddress()
+  const turbo = useContext(NovariaTurboContext)
+  const treasuryContract = getTreasuryAddress(turbo)
   const allowanceTreasury = useGetAllowance(treasuryContract)
   const treasuryContractApproved = allowanceTreasury === null ? null : allowanceTreasury > 0
 

--- a/src/views/Novaria/components/StartMenu.tsx
+++ b/src/views/Novaria/components/StartMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { useWallet } from '@binance-chain/bsc-use-wallet'
 import {
@@ -15,6 +15,7 @@ import ReactGA from 'react-ga'
 import ReactPixel from 'react-facebook-pixel'
 import { useHistory } from 'react-router-dom'
 import { usePriceNovaBusd } from 'state/hooks'
+import NovariaTurboContext from 'contexts/NovariaTurboContext'
 
 const Button = styled.button`
   cursor: pointer;
@@ -53,11 +54,13 @@ const StartMenu = () => {
   const [pendingApprove, setPendingApproveTx] = useState(false)
   const [name, setName] = useState('')
 
-  const fleetContract = getFleetAddress()
+  const turbo = useContext(NovariaTurboContext)
+
+  const fleetContract = getFleetAddress(turbo)
   const allowanceFleet = useGetAllowance(fleetContract)
   const fleetContractApproved = allowanceFleet === null ? null : allowanceFleet > 0
 
-  const treasuryContract = getTreasuryAddress()
+  const treasuryContract = getTreasuryAddress(turbo)
   const allowanceTreasury = useGetAllowance(treasuryContract)
   const treasuryContractApproved = allowanceTreasury === null ? null : allowanceTreasury > 0
 


### PR DESCRIPTION
Novaria specific contract address helpers (e.g. `getMapAddress`) now take a `turbo` boolean argument based on which they either return the Novaria turbo contract addresses or the Novaria default contract addresses.

The Novaria turbo contract addresses can be set under `constants/contracts.ts:turboContracts`, currently set to the Novaria default contract addresses.

Introduced a context provider called `NovariaTurboContext` to be used to indicate whether Novaria turbo is on, where needed. Some hooks using the contract address helpers mentioned above (e.g. `useMap`), to get the corresponding contract objects, were updated to automatically use this context provider to get the value for `turbo` they need to pass to the contract address helpers.

So, to switch the map, for example, to the Novaria turbo addresses, one could use:
```
...
<Route path="/map">
  <GlobalStyle isNovaria={false} isShipyard={false} isNovariaSpace isStandard={false} />
  <WalletProvider>
    <NovariaTurboContext.Provider value>
      <Map />
    </NovariaTurboContext.Provider>
  </WalletProvider>
</Route>
...
```

Additional notable cleanup:
- `useNovaria.ts` was not consistent and either used `getContract`, at the beginning of the file, to get and further use the Novaria fleet contract, for example, or the corresponding hook, in this case `useFleet`. Moved to using the hooks only to benefit from the Novaria turbo on / off detection.
 